### PR TITLE
Allow pure evaluation with md5 checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,12 +188,6 @@ Luckily, this installation method is not super common - most Dune-based projects
 
 A [workaround][dune-install-fix] has been accepted in Dune that will be available from version 3.2 onwards.
 
-### MD5 checksums in OPAM files
-
-Some OPAM packages express checksums using MD5 which is not accepted by Nix' `fetchurl` mechanism. The source of these packages therefore can't be fetched when running Nix in pure mode. Nix Flakes run pure mode by default.
-
-When you encounter Nix complaining about missing checksums in pure mode, try running with `--impure` while the package in question migrates to SHA256 checksums.
-
 [opam-repository]: https://github.com/ocaml/opam-repository
 [dune-install-issue]: https://github.com/ocaml/dune/issues/5455
 [dune-install-fix]: https://github.com/ocaml/dune/pull/5589

--- a/examples/flake/flake.nix
+++ b/examples/flake/flake.nix
@@ -23,6 +23,8 @@
               "opam-0install"
               "cmdliner"
               "ppx_deriving"
+              "base64"
+              "hex"
             ];
           };
         };

--- a/examples/standard/default.nix
+++ b/examples/standard/default.nix
@@ -26,6 +26,8 @@ let
         "opam-0install"
         "cmdliner"
         "ppx_deriving"
+        "base64"
+        "hex"
       ];
     };
   };

--- a/nix/packages/ocaml/opam0install2nix.nix
+++ b/nix/packages/ocaml/opam0install2nix.nix
@@ -2,6 +2,8 @@
 , opam-0install
 , cmdliner
 , zarith
+, hex
+, base64
 , pkgs
 }:
 
@@ -18,6 +20,8 @@ buildDunePackage {
     opam-0install
     cmdliner
     zarith
+    hex
+    base64
     pkgs.git
   ];
 }

--- a/nix/packages/ocaml/opam2nix.nix
+++ b/nix/packages/ocaml/opam2nix.nix
@@ -5,6 +5,8 @@
 , ppx_deriving
 , cmdliner
 , zarith
+, hex
+, base64
 , pkgs
 }:
 
@@ -24,6 +26,8 @@ buildDunePackage {
     ppx_deriving
     cmdliner
     zarith
+    hex
+    base64
     pkgs.git
   ];
 }

--- a/nix/packages/ocaml/opamsubst2nix.nix
+++ b/nix/packages/ocaml/opamsubst2nix.nix
@@ -1,6 +1,8 @@
 { buildDunePackage
 , opam-format
 , zarith
+, base64
+, hex
 , pkgs
 }:
 
@@ -16,6 +18,8 @@ buildDunePackage {
   buildInputs = [
     opam-format
     zarith
+    base64
+    hex
     pkgs.git
   ];
 }

--- a/nix/packages/ocaml/opamvars2nix.nix
+++ b/nix/packages/ocaml/opamvars2nix.nix
@@ -2,6 +2,8 @@
 , opam-format
 , opam-state
 , zarith
+, base64
+, hex
 , pkgs
 }:
 
@@ -18,6 +20,8 @@ buildDunePackage {
     opam-format
     opam-state
     zarith
+    base64
+    hex
     pkgs.git
   ];
 }

--- a/opam0install2nix.opam
+++ b/opam0install2nix.opam
@@ -7,6 +7,8 @@ depends: [
   "opam-0install"
   "cmdliner"
   "zarith"
+  "base64"
+  "hex"
   "odoc" {with-doc}
 ]
 build: [

--- a/opam2nix.opam
+++ b/opam2nix.opam
@@ -8,6 +8,8 @@ depends: [
   "cmdliner"
   "zarith"
   "ppx_deriving"
+  "base64"
+  "hex"
   "odoc" {with-doc}
 ]
 build: [

--- a/opamsubst2nix.opam
+++ b/opamsubst2nix.opam
@@ -5,6 +5,8 @@ depends: [
   "dune" {>= "2.9"}
   "opam-format"
   "zarith"
+  "base64"
+  "hex"
   "odoc" {with-doc}
 ]
 build: [

--- a/opamvars2nix.opam
+++ b/opamvars2nix.opam
@@ -6,6 +6,8 @@ depends: [
   "opam-format"
   "opam-state"
   "zarith"
+  "base64"
+  "hex"
   "odoc" {with-doc}
 ]
 build: [

--- a/src/opam2nix_lib/dune
+++ b/src/opam2nix_lib/dune
@@ -1,3 +1,3 @@
 (library
  (name opam2nix_lib)
- (libraries nix opam-format))
+ (libraries nix opam-format hex base64))

--- a/src/opam2nix_lib/opam2nix_lib.ml
+++ b/src/opam2nix_lib/opam2nix_lib.ml
@@ -81,7 +81,7 @@ let nix_of_commands commands =
 
 let hash_attrs hash =
   match OpamHash.kind hash with
-  | `MD5 -> None
+  | `MD5 -> Some ("hash", Nix.string ("md5-" ^ Base64.encode_string (Hex.to_string (`Hex (OpamHash.contents hash))) ^ "=="))
   | `SHA256 -> Some ("sha256", Nix.string (OpamHash.contents hash))
   | `SHA512 -> Some ("sha512", Nix.string (OpamHash.contents hash))
 ;;


### PR DESCRIPTION
Use `hash` argument to FODs to allow for md5 hashes.
