### PR TITLE
Draft: Make `opam.source.fix` no-longer dependent on `name` and `version` 

### DIFF
--- a/nix/lib/opam/source/default.nix
+++ b/nix/lib/opam/source/default.nix
@@ -6,19 +6,6 @@
   jq,
   unzip,
 }: let
-  mkSrcName = src: let
-    src' = toString src;
-  in
-    if src' != null && lib.strings.hasPrefix "/nix/store/" src'
-    then
-      lib.pipe src' [
-        (builtins.split "-")
-        builtins.tail
-        (builtins.filter builtins.isString)
-        (builtins.concatStringsSep "-")
-      ]
-    else "unknown";
-
   mkCopyExtraFilesScript = extraFiles:
     lib.concatStringsSep "\n" (
       lib.lists.map ({
@@ -34,13 +21,12 @@
   '';
 
   overlayExtraFiles = {
-    srcName,
     src,
     extraFiles,
     ...
   }:
     stdenv.mkDerivation {
-      name = "opam2nix-${srcName}-source-phase1";
+      name = "opam2nix-source-phase1";
 
       inherit src;
       dontUnpack = src == null;
@@ -82,15 +68,13 @@
 
   fixSource = {
     src,
-    extraFiles,
     substFiles,
     ...
   } @ args: let
-    srcName = mkSrcName args.src;
-    src = overlayExtraFiles (args // {inherit srcName;});
+    src = overlayExtraFiles args;
   in
     stdenv.mkDerivation {
-      name = "opam2nix-${srcName}-source";
+      name = "opam2nix-source";
 
       inherit src;
 

--- a/nix/scope/make-opam-derivation.nix
+++ b/nix/scope/make-opam-derivation.nix
@@ -160,7 +160,7 @@ in
       fi
     '';
 
-    overlayedSource = opamLib.source.fix {inherit name version src extraFiles substFiles;};
+    overlayedSource = opamLib.source.fix {inherit src extraFiles substFiles;};
 
     selectedPatches =
       lib.lists.map


### PR DESCRIPTION
# Motivation and Context

Currently `opam.source.fix` (`fixSource`) creates an intermediate derivation with a name dependent on the `.opam`'s
`name` and `version`. However, this causes issues in the context of `n` opam packages (with differing names) that share the same `src` (resulting in `n` duplications of `src`). 

# Description

This PR makes the derivation produces by `opam.source.fix` only dependent on `src`, `extraFiles` and `substFiles`. Thus permitting opam packages that have the same `src` to share the derivation produced by `opam.source.fix`. 



