### PR TITLE
chore: update opam to `> 2.2.0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688587528,
-        "narHash": "sha256-a1WlbVZyFtXVwqU/Ut+tl8aTgexp/GKloQtGA1Hfwjw=",
+        "lastModified": 1728990968,
+        "narHash": "sha256-U/JIxvuc8/cyiXS/vvkJRUqsxBKI0c/vfdJi9dDDhkU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08c696c8d702e98d6693efea6d0be94b54849a16",
+        "rev": "e273688024588b785258dde795c63cb5b2ef2cc8",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1688548241,
-        "narHash": "sha256-cmk1kCLtcL9GJplfl4J7t0r8g0N25O4G0ctycV4eyPo=",
+        "lastModified": 1728983546,
+        "narHash": "sha256-hi6Bm1PlcPzfxmV8DxcM0WhIOJcd29cfGexkRmVxftQ=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "860072345fa2f234ff10ffeee88db6906e138e92",
+        "rev": "cdc6ae9b86b5d59f665566d918bbf96a11804b7e",
         "type": "github"
       },
       "original": {

--- a/nix/boot/packages/0install-solver.nix
+++ b/nix/boot/packages/0install-solver.nix
@@ -11,7 +11,7 @@ buildDunePackage {
   src = fetchFromGitHub {
     owner = "0install";
     repo = "0install";
-    rev = "4a837bd638d93905b96d073c28c644894f8d4a0b";
-    sha256 = "sha256-OsHJNh99oEQxCUH4GuV1sAlUhxCIxcW3oodgojgRskw=";
+    rev = "225587eef889a3082e0cc53fa64500f56cca0028";
+    sha256 = "sha256-+d+2p5vJaVWTVroDvaDqzhcSlccTTt7ntWZ+TK8meuk=";
   };
 }

--- a/nix/boot/packages/opam-0install.nix
+++ b/nix/boot/packages/opam-0install.nix
@@ -15,8 +15,8 @@ buildDunePackage {
   src = fetchFromGitHub {
     owner = "ocaml-opam";
     repo = "opam-0install-solver";
-    rev = "eb08da5434a8c8227af39927b99b5cc15e82c053";
-    sha256 = "sha256-+AD5zSAKZ4k2G+RsrKq1MxzjuGV4qdfOpt4TJxDMlEk=";
+    rev = "f48784c0cf9625d9ed9aa95d7a61f495e619bd93";
+    sha256 = "sha256-Gf9m7xAP9G9Db1sWyGuWQgoJQjASVr4NrsjBwFBWibQ=";
   };
 
   propagatedBuildInputs = [

--- a/opam2nix.opam
+++ b/opam2nix.opam
@@ -4,7 +4,7 @@ synopsis: "Convert .opam files to Nix expressions"
 depends: [
   "dune" {>= "2.9"}
   "opam-format"
-  "opam-state" {< "2.2"}
+  "opam-state"
   "opam-0install"
   "cmdliner"
   "zarith"

--- a/src/solve_0install_command.ml
+++ b/src/solve_0install_command.ml
@@ -34,13 +34,13 @@ module Options = struct
 end
 
 let arch =
-  match OpamSysPoll.arch () with
+  match OpamSysPoll.arch OpamVariable.Map.empty with
   | None -> failwith "Failed to discover $arch"
   | Some arch -> arch
 ;;
 
 let os =
-  match OpamSysPoll.os () with
+  match OpamSysPoll.os OpamVariable.Map.empty with
   | None -> failwith "Failed to discover $os"
   | Some os -> os
 ;;


### PR DESCRIPTION
# Context

Currently, using the latest nixpkgs version, one runs into the following error:
```
error: builder for '/nix/store/w6lsvcalcrgvg0q94g7lbwkj32czlbcq-ocaml4.14.2-opam2nix-0.0.0.drv' failed with exit code 1;
       last 17 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/c8rnybgac5cf4k7y12cdg1s726p6xpj9-im328mqiqsk6171xsiwz1f9lsvvssvi0-source
       > source root is im328mqiqsk6171xsiwz1f9lsvvssvi0-source
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > (cd _build/default && /nix/store/7arzbkiccv969d78xy1k2gbwnpz1xfcv-ocaml-4.14.2/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.opam2nix.eobjs/byte -I /nix/store/364s0lc4s1p3351nj9zqd84dv3bybq5k-ocaml4.14.2-opam-state-2.2.0/lib/ocaml/4.14.2/site-lib/opam-state -I /nix/store/4vb2619wcl6pp6ndmbsy864lcvshz1hg-ocaml4.14.2-seq-0.1/lib/ocaml/4.14.2/site-lib/seq -I /nix/store/4z8kwi58zgcfd4n9xqbh01k60lkkvvzr-cmdliner-1.3.0/lib/ocaml/4.14.2/site-lib/cmdliner -I /nix/store/4za2wq73123avscaddy39vq7jiv78vcc-ocaml4.14.2-swhid_core-0.1/lib/ocaml/4.14.2/site-lib/swhid_core -I /nix/store/50fypsqjkrjj605n30vny2y1kbglk4kl-ocaml4.14.2-cstruct-6.2.0/lib/ocaml/4.14.2/site-lib/cstruct -I /nix/store/5587zpf4whn2w63wnw8ga4lxbplhvw84-ocaml4.14.2-opam-format-2.2.0/lib/ocaml/4.14.2/site-lib/opam-format -I /nix/store/6wcnbc8yzsyk8cmsr18hs8a48ydblljq-ocaml4.14.2-uutf-1.0.3/lib/ocaml/4.14.2/site-lib/uutf -I /nix/store/99w1jks5hx3559ghxlqakw5zbf1znj7c-ocaml4.14.2-ocamlgraph-2.1.0/lib/ocaml/4.14.2/site-lib/ocamlgraph -I /nix/store/cczs3ylr93bm3gb5kcjb6dc6j4ly12kp-ocaml4.14.2-re-1.11.0/lib/ocaml/4.14.2/site-lib/re -I /nix/store/cs9crhxsv0zyjbmflhc0d9bdyphy145y-ocaml4.14.2-jsonm-1.0.2/lib/ocaml/4.14.2/site-lib/jsonm -I /nix/store/f08dap5angsm2awk2xi2sh3mad6y2y98-ocaml4.14.2-fmt-0.9.0/lib/ocaml/4.14.2/site-lib/fmt -I /nix/store/iq3iw1pzn62sy1aclfpa5zpqz54wvw4g-ocaml4.14.2-opam-0install-0.4.2/lib/ocaml/4.14.2/site-lib/opam-0install -I /nix/store/jmm7r2ynb5p24k0k611bkl1g8jx0m3zk-ocaml4.14.2-0install-solver-2.17/lib/ocaml/4.14.2/site-lib/0install-solver -I /nix/store/m69fqfjwb9469bbm6j400djhl39h5pmb-ocaml4.14.2-result-1.5/lib/ocaml/4.14.2/site-lib/result -I /nix/store/nj3rcakm56m7vcvfr5svaq0jlg7g7xyj-ocaml4.14.2-zarith-1.14/lib/ocaml/4.14.2/site-lib/zarith -I /nix/store/npbc0gqgwnjis7sxxsgzicr703f13fsl-ocaml4.14.2-hex-1.5.0/lib/ocaml/4.14.2/site-lib/hex -I /nix/store/nylcwamp50gjb3s98wr0inn0r6jkwnjn-ocaml4.14.2-ppx_deriving-5.2.1/lib/ocaml/4.14.2/site-lib/ppx_deriving/runtime -I /nix/store/p3a3b2gibhyrn3xsnwkq2nvczwv1fw4j-ocaml4.14.2-stdlib-shims-0.3.0/lib/ocaml/4.14.2/site-lib/stdlib-shims -I /nix/store/padcq5rldzcaxcsixx0njin2jsiway0m-ocaml4.14.2-sha-1.15.4/lib/ocaml/4.14.2/site-lib/sha -I /nix/store/ph9809xyimif9sqqn1ixv1bh440gh8z9-ocaml4.14.2-spdx_licenses-1.2.0/lib/ocaml/4.14.2/site-lib/spdx_licenses -I /nix/store/pspx7m8z6wc7xcybscjhzwlv1nvai98w-ocaml4.14.2-opam-core-2.2.0/lib/ocaml/4.14.2/site-lib/opam-core -I /nix/store/wrkw2c9kq9ljjp4pj9ny5vic2m7jl65g-ocaml4.14.2-base64-3.5.1/lib/ocaml/4.14.2/site-lib/base64 -I /nix/store/yj19j962g83ncvckg1fzgnfdcfdrnl1c-ocaml4.14.2-opam-file-format-2.1.6/lib/ocaml/4.14.2/site-lib/opam-file-format -I /nix/store/zs5gvjh48x38zcr6zqvgs8bsmxpb6as2-ocaml4.14.2-opam-repository-2.2.0/lib/ocaml/4.14.2/site-lib/opam-repository -I src/nix/.opam2nix_nix.objs/byte -no-alias-deps -open Dune__exe -o src/.opam2nix.eobjs/byte/dune__exe__Solve_0install_command.cmo -c -impl src/solve_0install_command.pp.ml)
       > File "src/solve_0install_command.ml", line 37, characters 25-27:
       > 37 |   match OpamSysPoll.arch () with
       >                               ^^
       > Error: This expression has type unit but an expression was expected of type
       >          OpamStateTypes.gt_variables =
       >            (OpamTypes.variable_contents option Lazy.t * string)
       >            OpamVariable.Map.t
       >
       For full logs, run 'nix-store -l /nix/store/w6lsvcalcrgvg0q94g7lbwkj32czlbcq-ocaml4.14.2-opam2nix-0.0.0.drv'.
 ```

The error occurs as the latest version of nixpkgs uses opam 2.2.0, yet opam-nix-integration relies on opam < 2.2.0.

# Description

This PR updates opam2nix to use opam 2.2.0. This fixes the error. 

